### PR TITLE
Use `console.error` for `stderr` port.

### DIFF
--- a/src/Native/Runtime.js
+++ b/src/Native/Runtime.js
@@ -216,7 +216,7 @@ if (!Elm.fullscreen) {
                 var process = process || {};
                 var handler = process.stderr
                     ? function(v) { process.stderr.write(v); }
-                    : function(v) { console.log('Error:' + v); };
+                    : function(v) { console.error(v); };
                 ports.stderr.subscribe(handler);
             }
             if ('title' in ports) {


### PR DESCRIPTION
https://github.com/DeveloperToolsWG/console-object/blob/master/api.md#consoleerrorobject--object-

`console.error` logs an error message to the browser console. It's supported in all browsers back to IE8.

This code could actually be simplified to only use the `console` object since it's supported in node as well: http://nodejs.org/api/console.html

The only difference from writing directly to stdout/err is the addition of newlines to every message. I can amend this PR to make that change if that sounds alright.